### PR TITLE
Unified `u32` type for all screen size manipulations in miniquad

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,4 @@ features = [
 
 [dev-dependencies]
 glam = { version = "0.27.0", features = ["scalar-math"] }
+quad-rand = "*"

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -106,9 +106,9 @@ impl EventHandler for Stage {
 
 	fn mouse_motion_event(&mut self, x: f32, y: f32) {
 		let (w, h) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		let (x, y) = (x / w, 1. - y / h);
 		self.uniforms.blobs_positions[0] = (x, y);
 	}
@@ -119,9 +119,9 @@ impl EventHandler for Stage {
 		}
 
 		let (w, h) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		let (x, y) = (x / w, 1. - y / h);
 		let (dx, dy) = (rand(-1.0, 1.0), rand(-1.0, 1.0));
 

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -105,7 +105,10 @@ impl EventHandler for Stage {
 	}
 
 	fn mouse_motion_event(&mut self, x: f32, y: f32) {
-		let (w, h) = window::screen_size();
+		let (w, h) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		let (x, y) = (x / w, 1. - y / h);
 		self.uniforms.blobs_positions[0] = (x, y);
 	}
@@ -115,7 +118,10 @@ impl EventHandler for Stage {
 			return;
 		}
 
-		let (w, h) = window::screen_size();
+		let (w, h) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		let (x, y) = (x / w, 1. - y / h);
 		let (dx, dy) = (rand(-1.0, 1.0), rand(-1.0, 1.0));
 

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -124,7 +124,10 @@ impl EventHandler for Stage {
 		self.ctx.buffer_update(self.bindings.vertex_buffers[1], BufferSource::slice(&self.pos[..]));
 
 		// model-view-projection matrix
-		let (width, height) = window::screen_size();
+		let (width, height) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 50.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 12.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -125,9 +125,9 @@ impl EventHandler for Stage {
 
 		// model-view-projection matrix
 		let (width, height) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 50.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 12.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));

--- a/examples/mandelbrot.rs
+++ b/examples/mandelbrot.rs
@@ -82,7 +82,10 @@ impl Mandelbrot {
 	}
 	// Returns two floats (x and y) from -0.5 to 0.5, with (0.0, 0.0) being the center of the screen
 	fn norm_mouse_pos(self: &Self, x: f32, y: f32) -> (f32, f32) {
-		let screen_size = window::screen_size();
+		let screen_size = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		let pos = (4.0 * (x / screen_size.0 - 0.5).powi(3), 4.0 * (y / screen_size.1 - 0.5).powi(3));
 
 		pos
@@ -117,7 +120,10 @@ impl EventHandler for Mandelbrot {
 		ctx.apply_bindings(&self.bindings);
 
 		// make sure to not stretch
-		let screen_size = window::screen_size();
+		let screen_size = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 
 		let ratio = screen_size.1 / screen_size.0;
 		let (mut scale_x, mut scale_y) = if ratio <= 1.0 { (ratio, 1.0) } else { (1.0, 1.0 / ratio) };

--- a/examples/mandelbrot.rs
+++ b/examples/mandelbrot.rs
@@ -83,9 +83,9 @@ impl Mandelbrot {
 	// Returns two floats (x and y) from -0.5 to 0.5, with (0.0, 0.0) being the center of the screen
 	fn norm_mouse_pos(self: &Self, x: f32, y: f32) -> (f32, f32) {
 		let screen_size = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		let pos = (4.0 * (x / screen_size.0 - 0.5).powi(3), 4.0 * (y / screen_size.1 - 0.5).powi(3));
 
 		pos
@@ -121,9 +121,9 @@ impl EventHandler for Mandelbrot {
 
 		// make sure to not stretch
 		let screen_size = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 
 		let ratio = screen_size.1 / screen_size.0;
 		let (mut scale_x, mut scale_y) = if ratio <= 1.0 { (ratio, 1.0) } else { (1.0, 1.0 / ratio) };

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -153,7 +153,10 @@ impl EventHandler for Stage {
 	fn update(&mut self) {}
 
 	fn draw(&mut self) {
-		let (width, height) = window::screen_size();
+		let (width, height) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 3.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));
 		let view_proj = proj * view;

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -154,9 +154,9 @@ impl EventHandler for Stage {
 
 	fn draw(&mut self) {
 		let (width, height) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 3.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));
 		let view_proj = proj * view;

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -188,9 +188,9 @@ impl EventHandler for Stage {
 
 	fn draw(&mut self) {
 		let (width, height) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 3.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));
 		let view_proj = proj * view;
@@ -200,9 +200,9 @@ impl EventHandler for Stage {
 		let model = Mat4::from_rotation_y(self.ry) * Mat4::from_rotation_y(self.rx);
 
 		let (w, h) = {
-            let (w, h) = window::screen_size();
-            (w as f32, h as f32)
-        };
+			let (w, h) = window::screen_size();
+			(w as f32, h as f32)
+		};
 		// the offscreen pass, rendering an rotating, untextured cube into a render target image
 		self.ctx.begin_pass(Some(self.offscreen_pass), PassAction::clear_color(1.0, 1.0, 1.0, 1.0));
 		self.ctx.apply_pipeline(&self.offscreen_pipeline);

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -187,7 +187,10 @@ impl EventHandler for Stage {
 	}
 
 	fn draw(&mut self) {
-		let (width, height) = window::screen_size();
+		let (width, height) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		let proj = Mat4::perspective_rh_gl(60.0f32.to_radians(), width / height, 0.01, 10.0);
 		let view = Mat4::look_at_rh(vec3(0.0, 1.5, 3.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0));
 		let view_proj = proj * view;
@@ -196,7 +199,10 @@ impl EventHandler for Stage {
 		self.ry += 0.03;
 		let model = Mat4::from_rotation_y(self.ry) * Mat4::from_rotation_y(self.rx);
 
-		let (w, h) = window::screen_size();
+		let (w, h) = {
+            let (w, h) = window::screen_size();
+            (w as f32, h as f32)
+        };
 		// the offscreen pass, rendering an rotating, untextured cube into a render target image
 		self.ctx.begin_pass(Some(self.offscreen_pass), PassAction::clear_color(1.0, 1.0, 1.0, 1.0));
 		self.ctx.apply_pipeline(&self.offscreen_pipeline);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -134,11 +134,11 @@ pub struct Conf {
 	/// The preferred width of the window, ignored on wasm/android.
 	///
 	/// Default: 800
-	pub window_width: i32,
+	pub window_width: u32,
 	/// The preferred height of the window, ignored on wasm/android.
 	///
 	/// Default: 600
-	pub window_height: i32,
+	pub window_height: u32,
 	/// Whether the rendering canvas is full-resolution on HighDPI displays.
 	///
 	/// Default: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,9 @@ pub mod window {
 	/// The current framebuffer size in pixels.
 	/// If [`Conf::high_dpi``](crate::conf::Conf::high_dpi) was set to false, canvas|window size == framebuffer size.
 	/// If set to true, the framebuffer is scaled by the dpi.
-	pub fn screen_size() -> (f32, f32) {
+	pub fn screen_size() -> (u32, u32) {
 		let d = native_display().lock().unwrap();
-		(d.screen_width as f32, d.screen_height as f32)
+		(d.screen_width as u32, d.screen_height as u32)
 	}
 
 	/// The dpi scaling factor (window pixels to framebuffer pixels)

--- a/src/native/linux_wayland.rs
+++ b/src/native/linux_wayland.rs
@@ -368,7 +368,7 @@ where
 		let (tx, rx) = std::sync::mpsc::channel();
 		let clipboard = Box::new(WaylandClipboard);
 		crate::set_display(NativeDisplayData {
-			..NativeDisplayData::new(conf.window_width, conf.window_height, tx, clipboard)
+			..NativeDisplayData::new(conf.window_width as i32, conf.window_height as i32, tx, clipboard)
 		});
 
 		(display.client.wl_proxy_add_listener)(registry, &registry_listener as *const _ as _, &mut display as *mut _ as _);
@@ -477,7 +477,7 @@ where
 				extensions::xdg_decoration::ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
 			);
 		} else if conf.platform.wayland_use_fallback_decorations {
-			display.decorations = Some(decorations::Decorations::new(&mut display, conf.window_width, conf.window_height));
+			display.decorations = Some(decorations::Decorations::new(&mut display, conf.window_width as i32, conf.window_height as i32));
 		}
 
 		let event_handler = (f.take().unwrap())();

--- a/src/native/linux_x11/libx11_ex.rs
+++ b/src/native/linux_x11/libx11_ex.rs
@@ -145,10 +145,10 @@ impl LibX11 {
 		(*hints).flags |= PWinGravity;
 		if conf.window_resizable == false {
 			(*hints).flags |= PMinSize | PMaxSize;
-			(*hints).min_width = conf.window_width;
-			(*hints).min_height = conf.window_height;
-			(*hints).max_width = conf.window_width;
-			(*hints).max_height = conf.window_height;
+			(*hints).min_width = conf.window_width as i32;
+			(*hints).min_height = conf.window_height as i32;
+			(*hints).max_width = conf.window_width as i32;
+			(*hints).max_height = conf.window_height as i32;
 		}
 		(*hints).win_gravity = StaticGravity;
 		(self.XSetWMNormalHints)(display, window, hints);

--- a/src/native/wasm.rs
+++ b/src/native/wasm.rs
@@ -54,8 +54,8 @@ where
 	let high_dpi = conf.high_dpi;
 	let dpi = get_dpi_scale(high_dpi) as i32;
 
-	main_canvas.set_width((conf.window_width * dpi) as u32);
-	main_canvas.set_height((conf.window_height * dpi) as u32);
+	main_canvas.set_width((conf.window_width as i32 * dpi) as u32);
+	main_canvas.set_height((conf.window_height as i32 * dpi) as u32);
 	main_canvas.style().set_property("width", &format!("{}px", conf.window_width)).unwrap();
 	main_canvas.style().set_property("height", &format!("{}px", conf.window_height)).unwrap();
 	main_canvas.focus().unwrap();
@@ -302,7 +302,8 @@ fn init_keyboard_events(canvas: &HtmlCanvasElement) {
 
 		if let Some(key) = keycodes::get_keycode(&ev.code()) {
 			let keycode = keycodes::translate_keycode(key);
-			let repeat = ev.repeat();
+			// ? `key_up_event` takes only 2 arguments now, thus I removed it from the call
+			// let repeat = ev.repeat();
 			let modifiers = crate::KeyMods {
 				shift: ev.shift_key(),
 				ctrl: ev.ctrl_key(),
@@ -310,7 +311,7 @@ fn init_keyboard_events(canvas: &HtmlCanvasElement) {
 				logo: ev.meta_key(),
 			};
 
-			event_handler.key_up_event(keycode, modifiers, repeat);
+			event_handler.key_up_event(keycode, modifiers);
 		};
 	});
 


### PR DESCRIPTION
This includes [`screen_size`](https://docs.rs/miniquad/latest/miniquad/window/fn.screen_size.html) returning `(u32, u32)` instead of `(f32, f32)`, and [`Conf`](https://docs.rs/miniquad/latest/miniquad/conf/index.html) struct now requiring `window_width` and `window_height` as `u32` values.

The PR as well fixes some conversions and examples.